### PR TITLE
Bug Fix: Can now finish session when workout added to active session & now can update a session if a workout was added

### DIFF
--- a/src/pages/edit/session/[id].tsx
+++ b/src/pages/edit/session/[id].tsx
@@ -188,6 +188,7 @@ const EditSession: NextPage = () => {
 						]);
 						setWorkoutId(workoutId + 1);
 						setShowModal(false);
+						setDataChangeInForm(true);
 					}}
 					exercises={exercisesData ?? []}
 				/>
@@ -392,7 +393,7 @@ const EditSession: NextPage = () => {
 
 					{/* Action Buttons */}
 					{dataChangeInForm && (
-						<div className="flex space-x-4">
+						<div className="!mb-2 flex space-x-4">
 							<button
 								type="submit"
 								disabled={!!errorMessage}


### PR DESCRIPTION
…dling

## Execute Code Quality Steps
- [ ] If the PR includes prisma schema changes, did you create a migration?
- [ ] Run `npm run format`

 ## Describe Changes

- User can now finish session when workout added to active session, previously would not let them finish/complete
- User can now can update a session if a workout was added, previously was not showing the update button


